### PR TITLE
README table of contents and exception handling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,71 @@
+---
+name: Peeps bug
+about: Report a bug or unexpected behavior when running Peeps
+title: ""
+labels: bug
+assignees: ''
+
+---
+
+## Description of bug / unexpected behavior
+<!-- Add a clear and concise description of the problem you encountered. -->
+
+
+## Expected behavior
+<!-- Add a clear and concise description of what you expected to happen. -->
+
+
+## How to reproduce the issue
+<!-- Provide a piece of code illustrating the undesired behavior. -->
+
+<details><summary>Code for reproducing the problem</summary>
+
+```py
+Paste your code here.
+```
+
+</details>
+
+
+## Additional media files
+<!-- Paste in the files manim produced on rendering the code above. -->
+
+<details><summary>Images/GIFs</summary>
+
+<!-- PASTE MEDIA HERE -->
+
+</details>
+
+
+## Logs
+<details><summary>Terminal output</summary>
+
+```
+PASTE HERE OR PROVIDE LINK TO https://pastebin.com/ OR SIMILAR
+```
+
+<!-- Insert screenshots here (only when absolutely necessary, we prefer copy/pasted output!) -->
+
+</details>
+
+
+## System specifications
+
+<details><summary>System Details</summary>
+
+- OS (with version, e.g., Windows 10 v2004 or macOS 10.15 (Catalina)):
+- Python version (`python/py/python3 --version`):
+- Blender version (Icon to the left of `File` > About Blender):
+</details>
+
+<details><summary>FFMPEG</summary>
+
+Output of `ffmpeg -version`:
+
+```
+PASTE HERE
+```
+</details>
+
+## Additional comments
+<!-- Add further context that you think might be relevant for this issue here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Request a new feature for Manim
+title: ""
+labels: new feature
+assignees: ''
+
+---
+
+## Description of proposed feature
+<!-- Add a clear and concise description of the new feature, including a motivation: why do you think this will be useful? -->
+
+
+## How can the new feature be used?
+<!-- If possible, illustrate how this new feature could be used. -->
+
+
+## Additional comments
+<!-- Add further context that you think might be relevant. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Request a new feature for Manim
+about: Request a new feature for Peeps
 title: ""
 labels: new feature
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/installation_issue.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue.md
@@ -1,18 +1,11 @@
 ---
 name: Installation issue
-about: Report issues with the installation process of Manim
+about: Report issues with the installation process of Peeps
 title: ""
 labels: bug, installation
 assignees: ''
 
 ---
-
-#### Preliminaries
-
-- [ ] I have followed the latest version of the
-      [installation instructions](https://docs.manim.community/en/stable/installation.html).
-- [ ] I have checked the [troubleshooting page](https://docs.manim.community/en/stable/installation/troubleshooting.html) and my problem is either not mentioned there,
-      or the solution given there does not help.
 
 ## Description of error
 <!-- Add a clear and concise description of the problem you encountered. -->
@@ -38,19 +31,8 @@ PASTE HERE OR PROVIDE LINK TO https://pastebin.com/ OR SIMILAR
 <details><summary>System Details</summary>
 
 - OS (with version, e.g., Windows 10 v2004 or macOS 10.15 (Catalina)):
-- RAM:
 - Python version (`python/py/python3 --version`):
-- Installed modules (provide output from `pip list`):
-```
-PASTE HERE
-```
-</details>
-
-<details><summary>LaTeX details</summary>
-
-+ LaTeX distribution (e.g. TeX Live 2020):
-+ Installed LaTeX packages:
-<!-- output of `tlmgr list --only-installed` for TeX Live or a screenshot of the Packages page for MikTeX -->
+- Blender version (Icon to the left of `File` > About Blender):
 </details>
 
 <details><summary>FFMPEG</summary>

--- a/.github/ISSUE_TEMPLATE/installation_issue.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue.md
@@ -1,0 +1,66 @@
+---
+name: Installation issue
+about: Report issues with the installation process of Manim
+title: ""
+labels: bug, installation
+assignees: ''
+
+---
+
+#### Preliminaries
+
+- [ ] I have followed the latest version of the
+      [installation instructions](https://docs.manim.community/en/stable/installation.html).
+- [ ] I have checked the [troubleshooting page](https://docs.manim.community/en/stable/installation/troubleshooting.html) and my problem is either not mentioned there,
+      or the solution given there does not help.
+
+## Description of error
+<!-- Add a clear and concise description of the problem you encountered. -->
+
+
+## Installation logs
+<!-- Please paste the **full** terminal output; we can only help to identify the issue
+     when we receive all required information. -->
+
+<details><summary>Terminal output</summary>
+
+```
+PASTE HERE OR PROVIDE LINK TO https://pastebin.com/ OR SIMILAR
+```
+
+<!-- Insert screenshots here (only when absolutely necessary, we prefer copy/pasted output!) -->
+
+</details>
+
+
+## System specifications
+
+<details><summary>System Details</summary>
+
+- OS (with version, e.g., Windows 10 v2004 or macOS 10.15 (Catalina)):
+- RAM:
+- Python version (`python/py/python3 --version`):
+- Installed modules (provide output from `pip list`):
+```
+PASTE HERE
+```
+</details>
+
+<details><summary>LaTeX details</summary>
+
++ LaTeX distribution (e.g. TeX Live 2020):
++ Installed LaTeX packages:
+<!-- output of `tlmgr list --only-installed` for TeX Live or a screenshot of the Packages page for MikTeX -->
+</details>
+
+<details><summary>FFMPEG</summary>
+
+Output of `ffmpeg -version`:
+
+```
+PASTE HERE
+```
+</details>
+
+## Additional comments
+<!-- Add further context that you think might be relevant for this issue here. -->

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,0 +1,17 @@
+---
+name: Suggestion
+about: Make a suggestion for the enhancement of existing features
+title: ""
+labels: enhancement
+assignees: ''
+
+---
+
+## Enhancement proposal
+<!-- Add a clear and concise description of your enhancement proposal. In particular,
+     if your enhancement introduces changes to the API, illustrate them with
+     (fictional) code examples. -->
+
+
+## Additional comments
+<!-- Add further context that you think might be relevant. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!-- Please fill in these sections / delete as appropriate -->
+
+## Overview: What does this pull request change?
+<!--changelog-start-->
+
+<!--changelog-end-->
+
+## Motivation and Explanation: Why and how do your changes improve the library?
+<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
+
+
+## Further Information and Comments

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Introduction](#introduction)
   - [Benefits](#benefits)
   - [Drawbacks](#drawbacks)
@@ -17,7 +18,7 @@
 - [Trying Out Your First Script](#trying-out-your-first-script)
   - [Running the Script](#running-the-script)
   - [Rendering Animations](#rendering-animations)
-  - [Going Beyond the Basics](#going-beyond-the-basics)
+- [Going Beyond the Basics](#going-beyond-the-basics)
 - [Contributing](#contributing)
 - [License](#license)
 

--- a/peeps/frame.py
+++ b/peeps/frame.py
@@ -64,12 +64,14 @@ class Frame(object):
             function: renders out images if self.render is True.
         """
         # enter context manager
-        if self.render:
-            self.start()
-        yield self.rYield
+        try:
+            if self.render:
+                self.start()
+            yield self.rYield
         # exit context manager
-        if self.render:
-            self.stop()
+        finally:
+            if self.render:
+                self.stop()
 
     def rYield(self):
         """


### PR DESCRIPTION
Previous REAMDE table of contents had a minor formatting error (and also missed the table of contents itself).

One of the benefits`@contextmanager` is to allow `with ... as ...` to deal with exceptions properly if a `try ... finally ...` block is used. In this case, I think it's best if `self.stop()` is called upon an exception occurring while rendering (delete images, run ffmpeg, etc).